### PR TITLE
Renovate 設定の追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
+	"timezone": "Asia/Tokyo",
+	"labels": ["dependencies"],
+	"rangeStrategy": "bump",
+	"prConcurrentLimit": 5,
+	"packageRules": [
+		{
+			"matchDepTypes": ["devDependencies"],
+			"groupName": "dev dependencies",
+			"labels": ["dev-deps"]
+		},
+		{
+			"matchPackageNames": ["next", "react", "react-dom", "eslint-config-next"],
+			"groupName": "nextjs core",
+			"labels": ["nextjs"]
+		},
+		{
+			"matchPackagePrefixes": ["@opennextjs/"],
+			"groupName": "opennext",
+			"labels": ["cloudflare"]
+		},
+		{
+			"matchPackageNames": ["wrangler"],
+			"groupName": "cloudflare wrangler",
+			"labels": ["cloudflare"]
+		}
+	]
+}


### PR DESCRIPTION
### Motivation
- `package.json` の依存構成に合わせて依存更新を自動化しやすくするために Renovate の基本設定を追加します。 

### Description
- ルートに `renovate.json` を追加し、`config:recommended` を拡張した上で `timezone: Asia/Tokyo`、`rangeStrategy: bump`、`prConcurrentLimit: 5` を設定し、`devDependencies`、`next`/`react`/`react-dom`/`eslint-config-next`（Next.js コア）、`@opennextjs/*`（OpenNext）、および `wrangler` をそれぞれグルーピングする `packageRules` を追加しました。 

### Testing
- 自動化テスト（CI）やローカルでの `pnpm lint` 等は実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6c7868048325a1593baed4ffb70e)