### PR TITLE
Cloudflare Workersデプロイ用GitHub Actionsの追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ./.node-version
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm deploy


### PR DESCRIPTION
### Motivation
- main ブランチへプッシュされた際に既存の OpenNext デプロイコマンド（`pnpm deploy`）で Cloudflare Workers へ自動デプロイできるようにするため。 

### Description
- `.github/workflows/deploy.yml` を追加し、`pnpm install --frozen-lockfile` の後に `pnpm deploy` を実行するジョブを定義し、`CLOUDFLARE_API_TOKEN` と `CLOUDFLARE_ACCOUNT_ID` を GitHub Secrets から渡すように設定した。 

### Testing
- 自動テストは実行しておらずワークフローは追加のみで動作未確認のため、マージ後に main へプッシュして GitHub Actions 上での実行を確認してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69731fe06ab483259c3366794f7840e5)