### PR TITLE
モバイル表示でCTAボタンが反応しない問題を修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,7 +89,7 @@ export default function HomePage() {
 
             {/* Right - Character */}
             <motion.div
-              className="relative flex justify-center lg:justify-end"
+              className="pointer-events-none relative flex justify-center lg:justify-end"
               initial={{ opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
               transition={{ delay: 1, duration: 0.8 }}


### PR DESCRIPTION
### Motivation
- モバイル/タブレット表示でトップページの「View Works」「Contact」がタップできない問題があり、右カラムの装飾要素が操作領域を覆ってタップを奪っているため修正しました。

### Description
- `src/app/page.tsx` の右カラムを包む `motion.div` に `pointer-events-none` を追加し、装飾領域がポインターイベントを受け取らないように変更しました（装飾がリンクのタップを阻害しないようにする対応）。

### Testing
- `pnpm lint` を実行して問題がないことを確認しました（成功）。
- モバイル自動タップ検証のため `playwright` スクリプトを実行しましたが、実行環境の Chromium が SIGSEGV で起動できず検証は失敗しました（環境依存の障害）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974aa937ed88325a1850bb5e2268d23)