### PR TITLE
初回描画アニメーションの簡素化と静的アセットの長期キャッシュ設定

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,37 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/images/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/favicon.svg",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/components/page-transition.tsx
+++ b/src/components/page-transition.tsx
@@ -11,35 +11,15 @@ export function PageTransition({ children }: PageTransitionProps) {
   return (
     <LazyMotion features={domAnimation}>
       <m.div
-        initial={{ opacity: 0, y: 20 }}
+        initial={false}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -20 }}
         transition={{
-          duration: 0.5,
+          duration: 0.35,
           ease: [0.22, 1, 0.36, 1],
         }}
         className="min-h-screen"
       >
-        {/* Page reveal animation */}
-        <m.div
-          className="fixed inset-0 bg-primary z-[200] origin-left pointer-events-none"
-          initial={{ scaleX: 1 }}
-          animate={{ scaleX: 0 }}
-          transition={{
-            duration: 0.8,
-            ease: [0.22, 1, 0.36, 1],
-            delay: 0.1,
-          }}
-        />
-        <m.div
-          className="fixed inset-0 bg-background z-[199] origin-left pointer-events-none"
-          initial={{ scaleX: 1 }}
-          animate={{ scaleX: 0 }}
-          transition={{
-            duration: 0.8,
-            ease: [0.22, 1, 0.36, 1],
-          }}
-        />
         {children}
       </m.div>
     </LazyMotion>


### PR DESCRIPTION
### Motivation
- Lighthouse の計測で LCP やキャッシュに関するエラーが出ていたため、初回描画での過度な覆い（ページ全体を隠すアニメーション）を抑え LCP の計測と初期表示を優先する目的で変更しました。 
- また、静的アセットに適切なキャッシュヘッダーを付与して「Use efficient cache lifetimes」の指摘に対応しました。

### Description
- `src/components/page-transition.tsx` の初期アニメーションを無効化して `initial={false}` に変更し、遷移用の全面覆いアニメーションを削除して遷移の影響を小さくしました。 
- 同ファイルで遷移の `duration` を `0.5` から `0.35` に短縮して初期表示を素早く行うよう調整しました。 
- `next.config.ts` に `headers()` を追加し、`/_next/static/:path*`、`/images/:path*`、および `/favicon.svg` に対して `Cache-Control: public, max-age=31536000, immutable` を設定しました。 
- 変更はパフォーマンス改善（LCP 計測、キャッシュ寿命）を意図しており、ページ遷移の演出は控えめになります。 

### Testing
- 開発サーバー起動を自動化で確認するために `pnpm exec next dev --turbopack --hostname 0.0.0.0 --port 3000` を実行し、Next.js が起動して `Ready` になったことを確認しました（成功）。
- Playwright を使ったページキャプチャの自動実行を試行しましたが、ヘッドレス Chromium の起動が環境でクラッシュしスクリーンショット取得に失敗しました（失敗）。
- `pnpm lint` や `pnpm build` はこの変更で自動実行していないため、必要であれば CI／ローカルで `pnpm lint` と `pnpm build` を実行してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b1dc2c088325884c74ebbbb31d90)